### PR TITLE
Checks for file not found

### DIFF
--- a/src/main/java/org/sonar/plugins/swift/complexity/LizardMeasurePersistor.java
+++ b/src/main/java/org/sonar/plugins/swift/complexity/LizardMeasurePersistor.java
@@ -54,6 +54,12 @@ public class LizardMeasurePersistor {
         for (Map.Entry<String, List<Measure>> entry : measures.entrySet()) {
             File file = new File(fileSystem.baseDir(), entry.getKey());
             InputFile inputFile = fileSystem.inputFile(fileSystem.predicates().hasAbsolutePath(file.getAbsolutePath()));
+
+            if (inputFile == null) {
+                LOGGER.warn("file not included in sonar {}", entry.getKey());
+                continue;
+            }
+
             Resource resource = sensorContext.getResource(inputFile);
 
             if (resource != null) {

--- a/src/main/java/org/sonar/plugins/swift/coverage/CoberturaReportParser.java
+++ b/src/main/java/org/sonar/plugins/swift/coverage/CoberturaReportParser.java
@@ -24,6 +24,8 @@ import com.google.common.collect.Maps;
 import org.apache.commons.lang.StringUtils;
 import org.codehaus.staxmate.in.SMHierarchicCursor;
 import org.codehaus.staxmate.in.SMInputCursor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.SensorContext;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.fs.InputFile;
@@ -42,6 +44,8 @@ import java.util.Locale;
 import java.util.Map;
 
 final class CoberturaReportParser {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CoberturaReportParser.class);
 
     private final FileSystem fileSystem;
     private final Project project;
@@ -84,6 +88,12 @@ final class CoberturaReportParser {
                 String filePath = entry.getKey();
                 File file = new File(fileSystem.baseDir(), filePath);
                 InputFile inputFile = fileSystem.inputFile(fileSystem.predicates().hasAbsolutePath(file.getAbsolutePath()));
+
+                if (inputFile == null) {
+                    LOGGER.warn("file not included in sonar {}", filePath);
+                    continue;
+                }
+
                 Resource resource = context.getResource(inputFile);
                 if (resourceExists(resource)) {
                     for (Measure measure : entry.getValue().createMeasures()) {

--- a/src/main/java/org/sonar/plugins/swift/issues/swiftlint/SwiftLintReportParser.java
+++ b/src/main/java/org/sonar/plugins/swift/issues/swiftlint/SwiftLintReportParser.java
@@ -85,6 +85,11 @@ public class SwiftLintReportParser {
 
             InputFile inputFile = fileSystem.inputFile(fileSystem.predicates().hasAbsolutePath(filePath));
 
+            if (inputFile == null) {
+                LOGGER.warn("file not included in sonar {}", filePath);
+                continue;
+            }
+
             Issuable issuable = resourcePerspectives.as(Issuable.class, inputFile);
 
             if (issuable != null) {


### PR DESCRIPTION
I add checks for file not found in:
- Surefire parser
- SwiftLint parser
- Lizard parser
- Covertura parser

Plugin print warning with lost file if file not found in sonar resources.