### PR TITLE
Adapted sonar-runner. Working with xcode 8.1

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,7 @@
 # Required configuration #
 ##########################
 
+# Project key will also be used for binary file
 sonar.projectKey=prjKey
 sonar.projectName=prjName
 sonar.projectVersion=1.0

--- a/src/main/shell/run-sonar-swift.sh
+++ b/src/main/shell/run-sonar-swift.sh
@@ -176,6 +176,8 @@ appScheme=''; readParameter appScheme 'sonar.swift.appScheme'
 appConfiguration=''; readParameter appConfiguration 'sonar.swift.appConfiguration'
 # The name of your test scheme in Xcode
 testScheme=''; readParameter testScheme 'sonar.swift.testScheme'
+# The name of your binary file (application)
+binaryName=''; readParameter binaryName 'sonar.projectKey'
 
 # Read destination simulator
 destinationSimulator=''; readParameter destinationSimulator 'sonar.swift.simulator'
@@ -288,7 +290,7 @@ if [ "$unittests" = "on" ]; then
     if [[ ! -z "$workspaceFile" ]]; then
         slatherCmd+=( --workspace $workspaceFile)
     fi
-    slatherCmd+=( --scheme "$appScheme" $firstProject)
+    slatherCmd+=( --scheme "$appScheme" --binary-file "$binaryName" "$firstProject")
 
     runCommand /dev/stdout "${slatherCmd[@]}"
     mv sonar-reports/cobertura.xml sonar-reports/coverage.xml
@@ -330,7 +332,7 @@ fi
 
 # SonarQube
 echo -n 'Running SonarQube using SonarQube Runner'
-runCommand /dev/stdout sonar-runner
+runCommand /dev/stdout sonar-runner || runCommand /dev/stdout sonar-scanner
 
 # Kill progress indicator
 stopProgress


### PR DESCRIPTION
try to run sonar-runner when this fails run sonar-scanner instead.
added `--binary-file` to slather command based on [sonar-swift/#53](https://github.com/Backelite/sonar-swift/issues/53)

using sonar.projectKey as binary name