### PR TITLE
Binary name option

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,7 @@
 # Required configuration #
 ##########################
 
+# Project key will also be used for binary file
 sonar.projectKey=prjKey
 sonar.projectName=prjName
 sonar.projectVersion=1.0

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -28,6 +28,12 @@ sonar.swift.simulator=platform=iOS Simulator,name=iPhone 6,OS=9.2
 #sonar.swift.project=MyPrj.xcodeproj
 #sonar.swift.workspace=MyWrkSpc.xcworkspace
 
+# Specify your appname.
+# This will be something like "myApp"
+# Use when basename is different from targeted scheme. 
+# Or when slather fails with 'No product binary found'
+sonar.swift.appName=myApp
+
 # Scheme to build your application
 sonar.swift.appScheme=MyScheme
 

--- a/src/main/shell/run-sonar-swift.sh
+++ b/src/main/shell/run-sonar-swift.sh
@@ -176,6 +176,8 @@ appScheme=''; readParameter appScheme 'sonar.swift.appScheme'
 appConfiguration=''; readParameter appConfiguration 'sonar.swift.appConfiguration'
 # The name of your test scheme in Xcode
 testScheme=''; readParameter testScheme 'sonar.swift.testScheme'
+# The name of your binary file (application)
+binaryName=''; readParameter binaryName 'sonar.projectKey'
 
 # Read destination simulator
 destinationSimulator=''; readParameter destinationSimulator 'sonar.swift.simulator'
@@ -288,7 +290,7 @@ if [ "$unittests" = "on" ]; then
     if [[ ! -z "$workspaceFile" ]]; then
         slatherCmd+=( --workspace $workspaceFile)
     fi
-    slatherCmd+=( --scheme "$appScheme" $firstProject)
+    slatherCmd+=( --scheme "$appScheme" --binary-file "$binaryName" "$firstProject")
 
     runCommand /dev/stdout "${slatherCmd[@]}"
     mv sonar-reports/cobertura.xml sonar-reports/coverage.xml
@@ -330,7 +332,7 @@ fi
 
 # SonarQube
 echo -n 'Running SonarQube using SonarQube Runner'
-runCommand /dev/stdout sonar-runner
+runCommand /dev/stdout sonar-runner || runCommand /dev/stdout sonar-scanner
 
 # Kill progress indicator
 stopProgress

--- a/src/main/shell/run-sonar-swift.sh
+++ b/src/main/shell/run-sonar-swift.sh
@@ -177,7 +177,7 @@ appConfiguration=''; readParameter appConfiguration 'sonar.swift.appConfiguratio
 # The name of your test scheme in Xcode
 testScheme=''; readParameter testScheme 'sonar.swift.testScheme'
 # The name of your binary file (application)
-binaryName=''; readParameter binaryName 'sonar.projectKey'
+binaryName=''; readParameter binaryName 'sonar.swift.appName'
 
 # Read destination simulator
 destinationSimulator=''; readParameter destinationSimulator 'sonar.swift.simulator'
@@ -268,7 +268,7 @@ if [ "$unittests" = "on" ]; then
     mv build/reports/junit.xml sonar-reports/TEST-report.xml
 
 
-    echo -n 'Computing coverage report'
+    fprint '\nComputing coverage report\n'
 
     # Build the --exclude flags
     excludedCommandLineFlags=""
@@ -286,11 +286,19 @@ if [ "$unittests" = "on" ]; then
     projectArray=(${projectFile//,/ })
     firstProject=${projectArray[0]}
 
-    slatherCmd=($SLATHER_CMD coverage --input-format profdata $excludedCommandLineFlags --cobertura-xml --output-directory sonar-reports)
+    slatherCmd=($SLATHER_CMD coverage)
+    if [[ ! -z "$binaryName" ]]; then
+    	slatherCmd+=( --binary-basename "$binaryName")
+    fi
+
+    slatherCmd+=( --input-format profdata $excludedCommandLineFlags --cobertura-xml --output-directory sonar-reports)
+
     if [[ ! -z "$workspaceFile" ]]; then
         slatherCmd+=( --workspace $workspaceFile)
     fi
-    slatherCmd+=( --scheme "$appScheme" --binary-file "$binaryName" "$firstProject")
+    slatherCmd+=( --scheme "$appScheme" "$firstProject")
+
+    echo "${slatherCmd[@]}"
 
     runCommand /dev/stdout "${slatherCmd[@]}"
     mv sonar-reports/cobertura.xml sonar-reports/coverage.xml


### PR DESCRIPTION
When slather fails with an error saying `No product binary found` or when the application name is different from the targeted scheme the application name can be set.

This can be done in the sonar-project.properties file.
There is an if statement in the run-sonar-swift script that checks if the variable is empty or not.
If it's empty it won't be added to the command