### PR TITLE
adding quotes to projectfile in case project name is from two words

### DIFF
--- a/src/main/shell/run-sonar-swift.sh
+++ b/src/main/shell/run-sonar-swift.sh
@@ -310,6 +310,7 @@ if [ "$unittests" = "on" ]; then
     slatherCmd+=( --scheme "$appScheme" "$firstProject")
 
     echo "${slatherCmd[@]}"
+
     runCommand /dev/stdout "${slatherCmd[@]}"
     mv sonar-reports/cobertura.xml sonar-reports/coverage-swift.xml
 fi

--- a/src/main/shell/run-sonar-swift.sh
+++ b/src/main/shell/run-sonar-swift.sh
@@ -310,7 +310,6 @@ if [ "$unittests" = "on" ]; then
     slatherCmd+=( --scheme "$appScheme" "$firstProject")
 
     echo "${slatherCmd[@]}"
-    
     runCommand /dev/stdout "${slatherCmd[@]}"
     mv sonar-reports/cobertura.xml sonar-reports/coverage-swift.xml
 fi

--- a/src/main/shell/run-sonar-swift.sh
+++ b/src/main/shell/run-sonar-swift.sh
@@ -184,7 +184,7 @@ testScheme=''; readParameter testScheme 'sonar.swift.testScheme'
 # The name of your binary file (application)
 binaryName=''; readParameter binaryName 'sonar.swift.appName'
 # Get the path of plist file
-plistFile=`xcodebuild -showBuildSettings -project ${projectFile} | grep -i 'PRODUCT_SETTINGS_PATH' -m 1 | sed 's/[ ]*PRODUCT_SETTINGS_PATH = //'`
+plistFile=`xcodebuild -showBuildSettings -project "${projectFile}" | grep -i 'PRODUCT_SETTINGS_PATH' -m 1 | sed 's/[ ]*PRODUCT_SETTINGS_PATH = //'`
 # Number version from plist if no sonar.projectVersion
 numVerionFromPlist=`defaults read ${plistFile} CFBundleShortVersionString`
 
@@ -310,7 +310,7 @@ if [ "$unittests" = "on" ]; then
     slatherCmd+=( --scheme "$appScheme" "$firstProject")
 
     echo "${slatherCmd[@]}"
-
+    
     runCommand /dev/stdout "${slatherCmd[@]}"
     mv sonar-reports/cobertura.xml sonar-reports/coverage-swift.xml
 fi


### PR DESCRIPTION
- some of the project can be composed by multiple words such as: `My Mobile App.xcodeproj`
- adding quotes in order to run xcodebuild correctly.

