### PR TITLE
Lowercase "fastlane"

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ In SonarQube under Quality Profiles the used Linter can be specified by selectin
 Checkout the [Releases](https://github.com/Backelite/sonar-swift/releases) page.
 
 ### Launching an analysis
-If you use [Fastlane](https://fastlane.tools), please read [our Fastlane integration doc](docs/sonarqube-fastlane.md).
+If you use [fastlane](https://fastlane.tools), please read [our fastlane integration doc](docs/sonarqube-fastlane.md).
 Otherwise, run the ```run-sonar-swift.sh``` script from your Xcode project root folder
 
 ### Release history
@@ -66,7 +66,7 @@ Otherwise, run the ```run-sonar-swift.sh``` script from your Xcode project root 
 #### 0.3.2
 - SwiftLint 0.16.1 (75 rules now).
 - Fixed [Metric 'test_data' should not be computed by a Sensor](https://github.com/Backelite/sonar-swift/issues/61) with SonarQube 6.2
-- Fastlane documentation update by [mammuth](https://github.com/mammuth). See [PR 62](https://github.com/Backelite/sonar-swift/pull/62)
+- fastlane documentation update by [mammuth](https://github.com/mammuth). See [PR 62](https://github.com/Backelite/sonar-swift/pull/62)
 - run-sonar-swift.sh fix by [TheSkwiggs](https://github.com/mammuth). See [PR 64](https://github.com/Backelite/sonar-swift/pull/64)
 
 #### 0.3.1
@@ -82,8 +82,8 @@ Otherwise, run the ```run-sonar-swift.sh``` script from your Xcode project root 
 
 #### 0.2.4
 - Analysis does not fail anymore when an unkwown issue is reported by SwiftLint. See [issue 35](https://github.com/Backelite/sonar-swift/issues/35)
-- Fastlane documentation (thanks to [viteinfinite](https://github.com/viteinfinite)). See [PR 33](https://github.com/Backelite/sonar-swift/pull/33)
-- Fixed Fastlane JUnit report support
+- fastlane documentation (thanks to [viteinfinite](https://github.com/viteinfinite)). See [PR 33](https://github.com/Backelite/sonar-swift/pull/33)
+- Fixed fastlane JUnit report support
 - SwiftLint 0.11.1 support
 - Better return code suppot for run-sonar-swift.sh
 

--- a/docs/sonarqube-fastlane.md
+++ b/docs/sonarqube-fastlane.md
@@ -1,6 +1,6 @@
-# Using with Fastlane 🚀
+# Using with fastlane 🚀
 
-If you already use Fastlane, you can simply setup a new lane performing the analysis as follows:
+If you already use fastlane, you can simply setup a new lane performing the analysis as follows:
 
 ```ruby
 lane :metrics do
@@ -15,7 +15,7 @@ end
 
 ## Options
 
-Fastlane's `sonar` action allows you to define or override a number of SonarQube properties, such as `sonar.project-version`.
+fastlane's `sonar` action allows you to define or override a number of SonarQube properties, such as `sonar.project-version`.
 
 For instance:
 
@@ -23,7 +23,7 @@ For instance:
   sonar(project_version: "1.0b")
 ```
 
-You can read the complete documentation of Fastlane's `sonar` action on your terminal via:
+You can read the complete documentation of fastlane's `sonar` action on your terminal via:
 
 ```bash
   fastlane action sonar

--- a/sonar-swift-plugin/src/main/java/org/sonar/plugins/swift/surefire/SwiftSurefireParser.java
+++ b/sonar-swift-plugin/src/main/java/org/sonar/plugins/swift/surefire/SwiftSurefireParser.java
@@ -79,7 +79,7 @@ public final class SwiftSurefireParser {
 
         return dir.listFiles(new FilenameFilter() {
             public boolean accept(File dir, String name) {
-                // .junit is for Fastlane support
+                // .junit is for fastlane support
                 return (name.startsWith("TEST") && name.endsWith(".xml")) || (name.endsWith(".junit"));
             }
         });


### PR DESCRIPTION
This might seem like nitpicking, but fastlane is generally stylised with a lowercase "f". See for example the [official fastlane website](https://fastlane.tools) where you can see that it is lowercased everywhere. Therefore, to be consistent with the official documentation of fastlane, I would suggest making this edit