### PR TITLE
Added swiftlint custom rules extraction from a .swiftlint.yml file

### DIFF
--- a/updateSwiftLintProfile.groovy
+++ b/updateSwiftLintProfile.groovy
@@ -18,8 +18,11 @@
 // Update profile-swiftlint.xml from local rules.txt
 // Severity is determined from ...
 
+@Grab(group='org.yaml', module='snakeyaml', version='1.5')
+
 import groovy.xml.MarkupBuilder
 import groovy.json.JsonBuilder
+import org.yaml.snakeyaml.*
 
 def magicSerevityAttribution(rule) {
 
@@ -72,6 +75,20 @@ def readSwiftLintRules() {
         rule.description = matcher[0][3]
         rule.severity = magicSerevityAttribution(rule)
 
+    }
+
+    // Extract custom rule identifiers and get details
+    Yaml parser = new Yaml()
+    FileReader swiftlintDotfile =  new FileReader('.swiftlint.yml')
+    HashMap swiftlintDotfileContent = parser.load(swiftlintDotfile)
+    swiftlintDotfileContent.custom_rules.each {ruleKey, ruleContent ->
+
+        def rule = [:]
+        rule.key = ruleKey
+        rule.name = ruleContent.name
+        rule.description  = ruleContent.message
+
+        result.add rule
     }
 
     result


### PR DESCRIPTION
Hi,

I added this feature : custom swiftlint rules extraction from a local .swiftlint.yml

```yml
custom_rules:
  pirates_beat_ninjas: # rule identifier
    included: ".*\\.swift" # regex that defines paths to include during linting. optional.
    excluded: ".*Test\\.swift" # regex that defines paths to exclude during linting. optional
    name: "Pirates Beat Ninjas" # rule name. optional.
    regex: "([n,N]inja)" # matching pattern
    match_kinds: # SyntaxKinds to match. optional.
      - comment
      - identifier
    message: "Pirates are better than ninjas." # violation message. optional.
    severity: error # violation severity. optional.
  no_hiding_in_strings:
    regex: "([n,N]inja)"
    match_kinds: string
```
I found no better solution to do this has swiftlint rules must be described before the plugin packaging.

 