### PR TITLE
Fix NPE

### DIFF
--- a/sonar-swift-plugin/src/main/java/org/sonar/plugins/swift/surefire/data/SurefireStaxHandler.java
+++ b/sonar-swift-plugin/src/main/java/org/sonar/plugins/swift/surefire/data/SurefireStaxHandler.java
@@ -121,6 +121,9 @@ public class SurefireStaxHandler implements XmlStreamHandler {
 
     private static long getTimeAttributeInMS(String value) throws XMLStreamException {
         // hardcoded to Locale.ENGLISH see http://jira.codehaus.org/browse/SONAR-602
+		if (value == null) {
+			return 0L;
+		}
         try {
             Double time = ParsingUtils.parseNumber(value, Locale.ENGLISH);
             return !Double.isNaN(time) ? (long) ParsingUtils.scaleValue(time * 1000, 3) : 0L;

--- a/sonar-swift-plugin/src/main/java/org/sonar/plugins/swift/surefire/data/SurefireStaxHandler.java
+++ b/sonar-swift-plugin/src/main/java/org/sonar/plugins/swift/surefire/data/SurefireStaxHandler.java
@@ -121,9 +121,9 @@ public class SurefireStaxHandler implements XmlStreamHandler {
 
     private static long getTimeAttributeInMS(String value) throws XMLStreamException {
         // hardcoded to Locale.ENGLISH see http://jira.codehaus.org/browse/SONAR-602
-		if (value == null) {
-			return 0L;
-		}
+        if (value == null) {
+            return 0L;
+        }
         try {
             Double time = ParsingUtils.parseNumber(value, Locale.ENGLISH);
             return !Double.isNaN(time) ? (long) ParsingUtils.scaleValue(time * 1000, 3) : 0L;


### PR DESCRIPTION
When there is failed test in `report.junit`, we cannot find `time` attribute in the failed testcase. Then the function `getTimeAttributeInMS()` will throw a NullPointerException. So I made this fix to prevent the crash.