### PR TITLE
Add missing rule "compiler warning"  (OCLint / Clang) 

### DIFF
--- a/objclang/src/main/resources/com/sonar/sqale/oclint-model.xml
+++ b/objclang/src/main/resources/com/sonar/sqale/oclint-model.xml
@@ -1035,6 +1035,19 @@
                     <txt>min</txt>
                 </prop>
             </chc>
+            <chc>
+                <rule-repo>OCLint</rule-repo>
+                <rule-key>compiler warning</rule-key>
+                <prop>
+                    <key>remediationFunction</key>
+                    <txt>CONSTANT_ISSUE</txt>
+                </prop>
+                <prop>
+                    <key>offset</key>
+                    <val>10</val>
+                    <txt>min</txt>
+                </prop>
+            </chc>
         </chc>
         <chc>
             <key>RESOURCE_RELIABILITY</key>

--- a/objclang/src/main/resources/org/sonar/plugins/oclint/profile-oclint.xml
+++ b/objclang/src/main/resources/org/sonar/plugins/oclint/profile-oclint.xml
@@ -283,5 +283,9 @@
             <repositoryKey>OCLint</repositoryKey>
             <key>missing abstract method implementation</key>
         </rule>
+        <rule>
+            <repositoryKey>OCLint</repositoryKey>
+            <key>compiler warning</key>
+        </rule>
     </rules>
 </profile>

--- a/objclang/src/main/resources/org/sonar/plugins/oclint/rules.txt
+++ b/objclang/src/main/resources/org/sonar/plugins/oclint/rules.txt
@@ -563,3 +563,11 @@ Summary: Name: missing abstract method implementation
 Severity: 1
 Category: OCLint
 
+compiler warning
+----------------
+
+Summary: Name: compiler warning
+
+Severity: 3
+Category: OCLint
+


### PR DESCRIPTION
Sonar scanner was crashing because it looks for the rule "compiler warning" and can not find it