### PR TITLE
Fix oclint clang compiler warning

### DIFF
--- a/objclang/src/main/resources/org/sonar/plugins/oclint/profile-oclint.xml
+++ b/objclang/src/main/resources/org/sonar/plugins/oclint/profile-oclint.xml
@@ -29,6 +29,10 @@
         </rule>
         <rule>
             <repositoryKey>OCLint</repositoryKey>
+            <key>compiler warning</key>
+        </rule>
+        <rule>
+            <repositoryKey>OCLint</repositoryKey>
             <key>constant conditional operator</key>
         </rule>
         <rule>

--- a/objclang/src/main/resources/org/sonar/plugins/oclint/rules.txt
+++ b/objclang/src/main/resources/org/sonar/plugins/oclint/rules.txt
@@ -43,6 +43,14 @@ Summary: Name: broken oddness check
 Severity: 3
 Category: OCLint
 
+compiler warning
+----------
+
+Summary: Name: compiler warning
+
+Severity: 3
+Category: OCLint
+
 collapsible if statements
 ----------
 


### PR DESCRIPTION
Fixes: ERROR: The rule 'OCLint:compiler warning' does not exist
https://github.com/Backelite/sonar-swift/issues/166

This is a duplicate of the working pull request from the legacy objective-c project: https://github.com/Backelite/sonar-objective-c/pull/50
