### PR TITLE
Execute Lizard and Cobertura sensors only for Swift and Objective-C

### DIFF
--- a/sonar-swift-plugin/src/main/java/com/backelite/sonarqube/swift/complexity/LizardSensor.java
+++ b/sonar-swift-plugin/src/main/java/com/backelite/sonarqube/swift/complexity/LizardSensor.java
@@ -18,6 +18,8 @@
 package com.backelite.sonarqube.swift.complexity;
 
 import com.backelite.sonarqube.commons.Constants;
+import com.backelite.sonarqube.objectivec.lang.core.ObjectiveC;
+import com.backelite.sonarqube.swift.lang.core.Swift;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.fs.InputFile;
@@ -62,6 +64,7 @@ public class LizardSensor implements Sensor {
     @Override
     public void describe(SensorDescriptor descriptor) {
         descriptor
+                .onlyOnLanguages(ObjectiveC.KEY, Swift.KEY)
                 .name("Lizard")
                 .onlyOnFileType(InputFile.Type.MAIN);
     }

--- a/sonar-swift-plugin/src/main/java/com/backelite/sonarqube/swift/coverage/CoberturaSensor.java
+++ b/sonar-swift-plugin/src/main/java/com/backelite/sonarqube/swift/coverage/CoberturaSensor.java
@@ -19,6 +19,8 @@ package com.backelite.sonarqube.swift.coverage;
 
 
 import com.backelite.sonarqube.commons.Constants;
+import com.backelite.sonarqube.objectivec.lang.core.ObjectiveC;
+import com.backelite.sonarqube.swift.lang.core.Swift;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.fs.FileSystem;
@@ -69,6 +71,7 @@ public class CoberturaSensor implements Sensor {
     @Override
     public void describe(SensorDescriptor descriptor) {
         descriptor
+                .onlyOnLanguages(ObjectiveC.KEY, Swift.KEY)
                 .name("Cobertura")
                 .onlyOnFileType(InputFile.Type.MAIN);
     }


### PR DESCRIPTION
`Lizard` and `Cobertura` sensors are executed for any language project. We have in production a SonarQube server that analyzes Swift, Java and Python projects and for Java and Python projects no  `lizard-report.xml` is generated so we have this error:

> ERROR: Lizard Report not found .../sonar-reports/lizard-report.xml java.io.FileNotFoundException: .../sonar-reports/lizard-report.xml (No such file or directory) at java.io.FileInputStream.open0(Native Method) at java.io.FileInputStream.open(FileInputStream.java:195) at java.io.FileInputStream.<init>(FileInputStream.java:138) at java.io.FileInputStream.<init>(FileInputStream.java:93) at sun.net.www.protocol.file.FileURLConnection.connect(FileURLConnection.java:90) at sun.net.www.protocol.file.FileURLConnection.getInputStream(FileURLConnection.java:188) at com.sun.org.apache.xerces.internal.impl.XMLEntityManager.setupCurrentEntity(XMLEntityManager.java:623) at com.sun.org.apache.xerces.internal.impl.XMLVersionDetector.determineDocVersion(XMLVersionDetector.java:148) at com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:805) at com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:770) at com.sun.org.apache.xerces.internal.parsers.XMLParser.parse(XMLParser.java:141) at com.sun.org.apache.xerces.internal.parsers.DOMParser.parse(DOMParser.java:243) at com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderImpl.parse(DocumentBuilderImpl.java:339) at javax.xml.parsers.DocumentBuilder.parse(DocumentBuilder.java:205) at org.sonar.plugins.swift.complexity.LizardReportParser.parseReport(LizardReportParser.java:65) at org.sonar.plugins.swift.complexity.LizardSensor.parseReportsIn(LizardSensor.java:69) at org.sonar.plugins.swift.complexity.LizardSensor.analyse(LizardSensor.java:60) at org.sonar.scanner.phases.SensorsExecutor.executeSensor(SensorsExecutor.java:57) at org.sonar.scanner.phases.SensorsExecutor.execute(SensorsExecutor.java:49) at org.sonar.scanner.phases.AbstractPhaseExecutor.execute(AbstractPhaseExecutor.java:78) at org.sonar.scanner.scan.ModuleScanContainer.doAfterStart(ModuleScanContainer.java:182) at org.sonar.core.platform.ComponentContainer.startComponents(ComponentContainer.java:142) at org.sonar.core.platform.ComponentContainer.execute(ComponentContainer.java:127) at org.sonar.scanner.scan.ProjectScanContainer.scan(ProjectScanContainer.java:247) at org.sonar.scanner.scan.ProjectScanContainer.scanRecursively(ProjectScanContainer.java:242) at org.sonar.scanner.scan.ProjectScanContainer.doAfterStart(ProjectScanContainer.java:232) at org.sonar.core.platform.ComponentContainer.startComponents(ComponentContainer.java:142) at org.sonar.core.platform.ComponentContainer.execute(ComponentContainer.java:127) at org.sonar.scanner.task.ScanTask.execute(ScanTask.java:47) at org.sonar.scanner.task.TaskContainer.doAfterStart(TaskContainer.java:86) at org.sonar.core.platform.ComponentContainer.startComponents(ComponentContainer.java:142) at org.sonar.core.platform.ComponentContainer.execute(ComponentContainer.java:127) at org.sonar.scanner.bootstrap.GlobalContainer.executeTask(GlobalContainer.java:115) at org.sonar.batch.bootstrapper.Batch.executeTask(Batch.java:116) at org.sonarsource.scanner.api.internal.batch.BatchIsolatedLauncher.execute(BatchIsolatedLauncher.java:63) at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) at java.lang.reflect.Method.invoke(Method.java:498) at org.sonarsource.scanner.api.internal.IsolatedLauncherProxy.invoke(IsolatedLauncherProxy.java:60) at com.sun.proxy.$Proxy0.execute(Unknown Source) at org.sonarsource.scanner.api.EmbeddedScanner.doExecute(EmbeddedScanner.java:233) at org.sonarsource.scanner.api.EmbeddedScanner.runAnalysis(EmbeddedScanner.java:151) at org.sonarsource.scanner.cli.Main.runAnalysis(Main.java:123) at org.sonarsource.scanner.cli.Main.execute(Main.java:77) at org.sonarsource.scanner.cli.Main.main(Main.java:61)

More info: https://github.com/Backelite/sonar-swift/issues/86

These two sensors only should be executed for Swift and Objective-C projects.