### PR TITLE
Added swiftlint unused_setter_value rule

### DIFF
--- a/swiftlang/src/main/resources/org/sonar/plugins/swiftlint/profile-swiftlint.xml
+++ b/swiftlang/src/main/resources/org/sonar/plugins/swiftlint/profile-swiftlint.xml
@@ -529,6 +529,10 @@
         </rule>
         <rule>
             <repositoryKey>SwiftLint</repositoryKey>
+            <key>unused_setter_value</key>
+        </rule>
+        <rule>
+            <repositoryKey>SwiftLint</repositoryKey>
             <key>valid_ibinspectable</key>
         </rule>
         <rule>

--- a/swiftlang/src/main/resources/org/sonar/plugins/swiftlint/rules.json
+++ b/swiftlang/src/main/resources/org/sonar/plugins/swiftlint/rules.json
@@ -917,6 +917,13 @@
     "severity": "MINOR"
   },
   {
+    "key": "unused_setter_value",
+    "category": "SwiftLint",
+    "name": "Unused Setter Value",
+    "description": "Setter value (i.e. newValue) is not used.",
+    "severity": "MINOR"
+  },
+  {
     "key": "valid_ibinspectable",
     "category": "SwiftLint",
     "name": "Valid IBInspectable",


### PR DESCRIPTION
Add support for the new Swiftlint unused_setter_value.

This is the same change as PR #203, just using the master branch as the base