### PR TITLE
fix lizard report route

### DIFF
--- a/docs/sonarqube-fastlane.md
+++ b/docs/sonarqube-fastlane.md
@@ -9,7 +9,7 @@ Then add the following lane.
 lane :metrics do
     scan(scheme: "[SCHEME]", code_coverage: true, derived_data_path: "./DerivedData", output_directory: "./reports")
     slather(cobertura_xml: true, jenkins: true, scheme: "[SCHEME]", build_directory: "./DerivedData", output_directory: "./reports", proj: "./[PROJECT].xcodeproj")
-    lizard(source_folder: "[SOURCE_FOLDER]", language: "swift", export_type: "xml", report_file: "report/lizard-report.xml")
+    lizard(source_folder: "[SOURCE_FOLDER]", language: "swift", export_type: "xml", report_file: "reports/lizard-report.xml")
     swiftlint(output_file: "./reports/swiftlint.txt", ignore_exit_status: true)
     sonar
 end


### PR DESCRIPTION
Lizard route does not match documented in **sonar-project.properties** section

previous: "report/lizard-report.xml"
corrected: "reports/lizard-report.xml"

This was resulting on failing to create a proper sonar report following documentation