### PR TITLE
feat: metrics lane replicating the run-sonar-swift.sh script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 #### Bug Fixes
 
-- None.
+- Support spaces in sonar.swift.appScheme parameter 
 
 ## v0.4.6
 

--- a/docs/sonarqube-fastlane.md
+++ b/docs/sonarqube-fastlane.md
@@ -2,7 +2,7 @@
 
 If you already use fastlane, you can simply setup a new lane performing the analysis as follows:
 
-Add `fastlane-plugin-lizard` gem into `Gemfile`, run `bundle install`
+Add `fastlane-plugin-lizard` and `java-properties` gems into `Gemfile`, run `bundle install`
 
 Then copy the file `sonar-swift-plugin/src/main/fastlane/sonar.rb` in your project and import it in your Fastfile.
 

--- a/docs/sonarqube-fastlane.md
+++ b/docs/sonarqube-fastlane.md
@@ -4,42 +4,18 @@ If you already use fastlane, you can simply setup a new lane performing the anal
 
 Add `fastlane-plugin-lizard` gem into `Gemfile`, run `bundle install`
 
-Then add the following lane.
-```ruby
-lane :metrics do
-    scan(scheme: "[SCHEME]", code_coverage: true, derived_data_path: "./DerivedData", output_directory: "./reports")
-    slather(cobertura_xml: true, jenkins: true, scheme: "[SCHEME]", build_directory: "./DerivedData", output_directory: "./reports", proj: "./[PROJECT].xcodeproj")
-    lizard(source_folder: "[SOURCE_FOLDER]", language: "swift", export_type: "xml", report_file: "reports/lizard-report.xml")
-    swiftlint(output_file: "./reports/swiftlint.txt", ignore_exit_status: true)
-    sonar
-end
-
-```
-
-## Options
-
-fastlane's `sonar` action allows you to define or override a number of SonarQube properties, such as `sonar.project-version`.
-
-For instance:
+Then copy the file `sonar-swift-plugin/src/main/fastlane/sonar.rb` in your project and import it in your Fastfile.
 
 ```ruby
-  sonar(project_version: "1.0b")
+import "sonar.rb"
 ```
 
-You can read the complete documentation of fastlane's `sonar` action on your terminal via:
+The lane `:metrics` is then available. To run the analysis, call:
 
 ```bash
-  fastlane action sonar
+$ fastlane metrics
 ```
 
 ## `sonar-project.properties`
 
-Please note that, in order to have your analysis performed via the tools above, you'll need to setup your `sonar-project.properties` file accordingly, as per the following example.
-
-```
-sonar.junit.reportsPath=reports/
-sonar.junit.include=*.junit
-sonar.swift.lizard.report=reports/lizard-report.xml
-sonar.swift.coverage.reportPattern=reports/cobertura.xml
-sonar.swift.swiftlint.report=reports/*swiftlint.txt
-```
+Please note that, in order to have your analysis performed via the tools above, you'll need to setup your `sonar-project.properties` file.

--- a/docs/sonarqube-fastlane.md
+++ b/docs/sonarqube-fastlane.md
@@ -2,9 +2,16 @@
 
 If you already use fastlane, you can simply setup a new lane performing the analysis as follows:
 
-Add `fastlane-plugin-lizard` and `java-properties` gems into `Gemfile`, run `bundle install`
+Add `java-properties` to your Gemfile and run `bundle install`.
 
-Then copy the file `sonar-swift-plugin/src/main/fastlane/sonar.rb` in your project and import it in your Fastfile.
+Install lizard locally and add the Fastlane plugin:
+
+```sh
+$ pip install lizard ./tools/lizard
+$ fastlane add_plugin lizard
+```
+
+Then copy the file `sonar-swift-plugin/src/main/fastlane/sonar.rb` in your project (`./fastlane/`) and import it in your Fastfile.
 
 ```ruby
 import "sonar.rb"
@@ -13,7 +20,7 @@ import "sonar.rb"
 The lane `:metrics` is then available. To run the analysis, call:
 
 ```bash
-$ fastlane metrics
+$ fastlane metrics sonar_url:<YOUR_SONAR_URL> sonar_login:<YOUR_SONAR_LOGIN>
 ```
 
 ## `sonar-project.properties`

--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,8 @@
                     </properties>
                     <excludes>
                         <exclude>**/README</exclude>
-                        <exclude>**/*/sh</exclude>
+                        <exclude>**/*/run-sonar-swift.sh</exclude>
+                        <exclude>**/*/sonar.rb</exclude>
                         <exclude>src/test/resources/**</exclude>
                         <exclude>src/main/resources/**</exclude>
                     </excludes>

--- a/sonar-swift-plugin/src/main/fastlane/sonar.rb
+++ b/sonar-swift-plugin/src/main/fastlane/sonar.rb
@@ -122,8 +122,5 @@ end
 
 desc "Run sonar-scanner"
 private_lane :sonar_run_scanner do |options|
-	sonar(
-		project_configuration_path: "sonar-project.properties",
-		sonar_url: "http://localhost:9000"
-	)
+	sonar(project_configuration_path: "sonar-project.properties")
 end

--- a/sonar-swift-plugin/src/main/fastlane/sonar.rb
+++ b/sonar-swift-plugin/src/main/fastlane/sonar.rb
@@ -1,3 +1,21 @@
+#
+# backelite-sonar-swift-plugin - Enables analysis of Swift and Objective-C projects into SonarQube.
+# Copyright © 2019 David Yang (david.tcha.yang@gmail.com)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
 require "java-properties"
 require 'shellwords'
 
@@ -12,8 +30,7 @@ lane :metrics do
 	sonar_run_slather(properties: properties, output_directory: default_output_directory, derived_data_path: derived_data_path)
 	sonar_run_oclint(properties: properties, output_directory: default_output_directory)
 	sonar_run_swiftlint(properties: properties, output_directory: default_output_directory)
-	# TODO : Uncomment once Lizard Parser is fixed
-	# sonar_run_lizard(properties: properties, output_directory: default_output_directory)
+	sonar_run_lizard(properties: properties, output_directory: default_output_directory)
 	sonar_run_scanner()
 end
 
@@ -54,24 +71,17 @@ end
 desc "Run Slather coverage"
 private_lane :sonar_run_slather do |options|
 	# Extract sonar property values
-	app_name 						= options[:properties][:"sonar.swift.appName"]
-	other_binary_names 				= options[:properties][:"sonar.coverage.otherBinaryNames"]
+	binary_basename 				= options[:properties][:"sonar.coverage.binaryNames"]
 	app_scheme 						= options[:properties][:"sonar.swift.appScheme"]
 	excluded_paths_from_coverage 	= options[:properties][:"sonar.swift.excludedPathsFromCoverage"]
 	project 						= options[:properties][:"sonar.swift.project"]
 
-	binary_basename = [app_name]
-	unless other_binary_names.nil?
-		binary_basename.push(*other_binary_names.split(","))
-	end
-	puts "Binary basename : #{binary_basename}"
-
 	slather(
 	   	cobertura_xml: true, 
-    	scheme: app_scheme,
+	   	scheme: app_scheme,
 	   	input_format: "profdata", 
 	   	ignore: excluded_paths_from_coverage.split(","), 
-	   	binary_basename: binary_basename,
+	   	binary_basename: binary_basename.split(","),
 	   	build_directory: options[:derived_data_path], 
 	   	output_directory: options[:output_directory],
 	   	proj: project

--- a/sonar-swift-plugin/src/main/fastlane/sonar.rb
+++ b/sonar-swift-plugin/src/main/fastlane/sonar.rb
@@ -1,0 +1,129 @@
+require "java-properties"
+require 'shellwords'
+
+desc "Launch code analysis for SonarQube"
+lane :metrics do
+	properties = JavaProperties.load(File.join(ENV["PWD"], "sonar-project.properties"))
+	default_output_directory = "./sonar-reports"
+	derived_data_path = "./DerivedData"
+
+	sonar_run_build(properties: properties, output_directory: default_output_directory)
+	sonar_run_tests(properties: properties, output_directory: default_output_directory, derived_data_path: derived_data_path)
+	sonar_run_slather(properties: properties, output_directory: default_output_directory, derived_data_path: derived_data_path)
+	sonar_run_oclint(properties: properties, output_directory: default_output_directory)
+	sonar_run_swiftlint(properties: properties, output_directory: default_output_directory)
+	# TODO : Uncomment once Lizard Parser is fixed
+	# sonar_run_lizard(properties: properties, output_directory: default_output_directory)
+	sonar_run_scanner()
+end
+
+desc "Run and build project to gather compile commands database"
+private_lane :sonar_run_build do |options|
+	# Extract sonar property values
+	workspace	= options[:properties][:"sonar.swift.workspace"]
+	app_scheme	= options[:properties][:"sonar.swift.appScheme"]
+
+	gym(
+    	workspace: workspace,
+    	scheme: app_scheme, 
+    	clean: true,
+    	skip_package_ipa: true,
+    	xcpretty_report_json: options[:output_directory] + "/compile_commands.json",
+    	xcargs: "COMPILER_INDEX_STORE_ENABLE=NO"
+	)
+end
+
+desc "Run unit tests"
+private_lane :sonar_run_tests do |options|
+	# Extract sonar property values
+	workspace	= options[:properties][:"sonar.swift.workspace"]
+	app_scheme	= options[:properties][:"sonar.swift.appScheme"]
+
+	run_tests(
+    	workspace: workspace,
+    	scheme: app_scheme, 
+    	clean: false,
+    	code_coverage: true, 
+    	derived_data_path: options[:derived_data_path], 
+    	output_directory: options[:output_directory],
+    	output_types: "junit",
+    	output_files: "TEST-report.xml"
+    )
+end
+
+desc "Run Slather coverage"
+private_lane :sonar_run_slather do |options|
+	# Extract sonar property values
+	app_name 						= options[:properties][:"sonar.swift.appName"]
+	other_binary_names 				= options[:properties][:"sonar.coverage.otherBinaryNames"]
+	app_scheme 						= options[:properties][:"sonar.swift.appScheme"]
+	excluded_paths_from_coverage 	= options[:properties][:"sonar.swift.excludedPathsFromCoverage"]
+	project 						= options[:properties][:"sonar.swift.project"]
+
+	binary_basename = [app_name]
+	unless other_binary_names.nil?
+		binary_basename.push(*other_binary_names.split(","))
+	end
+	puts "Binary basename : #{binary_basename}"
+
+	slather(
+	   	cobertura_xml: true, 
+    	scheme: app_scheme,
+	   	input_format: "profdata", 
+	   	ignore: excluded_paths_from_coverage.split(","), 
+	   	binary_basename: binary_basename,
+	   	build_directory: options[:derived_data_path], 
+	   	output_directory: options[:output_directory],
+	   	proj: project
+	)
+    # Rename the file
+    sh "cd ../#{options[:output_directory]} && mv cobertura.xml coverage-swift.xml"
+end
+
+desc "Run OCLint analysis"
+private_lane :sonar_run_oclint do |options|
+	# Extract sonar property values
+	sources = options[:properties][:"sonar.sources"]
+
+	sources.split(",").each do |source|
+		# if source path contains objective-c file (*.m)
+		unless Dir.glob("../#{source}/**/*.m").empty?
+			output_filename = source.gsub("/", "_") + "-oclint.xml"
+			sh "cd ../#{options[:output_directory]} && oclint-json-compilation-database -v --include .*/#{source} -- -rc LONG_LINE=250 -max-priority-1 10000 -max-priority-2 10000 -max-priority-3 10000 -report-type pmd -o #{output_filename}"
+		end
+	end
+end
+
+desc "Run Lizard"
+private_lane :sonar_run_lizard do |options|
+	# Extract sonar property values
+	sources = options[:properties][:"sonar.sources"]
+
+	source_folders = sources.split(",").map { |source| source.shellescape }.join(" ")
+	lizard(
+		source_folder: source_folders,
+		language: 'swift,objectivec',
+		export_type: 'xml',
+		report_file: options[:output_directory] + '/lizard-report.xml'
+	)
+end
+
+desc "Run SwiftLint analysis"
+private_lane :sonar_run_swiftlint do |options|
+	# Extract sonar property values
+	sources = options[:properties][:"sonar.sources"]
+
+	# iterating through each sources path
+	sources.split(",").each do |source|
+		output_filename = options[:output_directory] + "/" + source.gsub("/", "_") + "-swiftlint.txt"
+		swiftlint(mode: :lint, path: source, output_file: output_filename, ignore_exit_status: true)
+	end
+end
+
+desc "Run sonar-scanner"
+private_lane :sonar_run_scanner do |options|
+	sonar(
+		project_configuration_path: "sonar-project.properties",
+		sonar_url: "http://localhost:9000"
+	)
+end

--- a/sonar-swift-plugin/src/main/fastlane/sonar.rb
+++ b/sonar-swift-plugin/src/main/fastlane/sonar.rb
@@ -76,16 +76,28 @@ private_lane :sonar_run_slather do |options|
 	excluded_paths_from_coverage 	= options[:properties][:"sonar.swift.excludedPathsFromCoverage"]
 	project 						= options[:properties][:"sonar.swift.project"]
 
-	slather(
-	   	cobertura_xml: true, 
-	   	scheme: app_scheme,
-	   	input_format: "profdata", 
-	   	ignore: excluded_paths_from_coverage.split(","), 
-	   	binary_basename: binary_basename.split(","),
-	   	build_directory: options[:derived_data_path], 
-	   	output_directory: options[:output_directory],
-	   	proj: project
-	)
+	if binary_basename.nil? || binary_basename.empty?
+		slather(
+		   	cobertura_xml: true, 
+		   	scheme: app_scheme,
+		   	input_format: "profdata", 
+		   	ignore: excluded_paths_from_coverage.split(","), 
+		   	build_directory: options[:derived_data_path], 
+		   	output_directory: options[:output_directory],
+		   	proj: project
+		)
+	else
+		slather(
+		   	cobertura_xml: true, 
+		   	scheme: app_scheme,
+		   	input_format: "profdata", 
+		   	ignore: excluded_paths_from_coverage.split(","), 
+		   	binary_basename: binary_basename.split(","),
+		   	build_directory: options[:derived_data_path], 
+		   	output_directory: options[:output_directory],
+		   	proj: project
+		)
+	end
     # Rename the file
     sh "cd ../#{options[:output_directory]} && mv cobertura.xml coverage-swift.xml"
 end

--- a/sonar-swift-plugin/src/main/fastlane/sonar.rb
+++ b/sonar-swift-plugin/src/main/fastlane/sonar.rb
@@ -1,6 +1,6 @@
 #
-# backelite-sonar-swift-plugin - Enables analysis of Swift and Objective-C projects into SonarQube.
-# Copyright © 2019 David Yang (david.tcha.yang@gmail.com)
+# sonar-swift-plugin - Enables analysis of Swift and Objective-C projects into SonarQube.
+# Copyright © 2022 David Yang (david.tcha.yang@gmail.com)
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by

--- a/sonar-swift-plugin/src/main/fastlane/sonar.rb
+++ b/sonar-swift-plugin/src/main/fastlane/sonar.rb
@@ -23,7 +23,6 @@ desc "Launch code analysis for SonarQube"
 lane :metrics do |options|
 	properties = JavaProperties.load(File.join(ENV["PWD"], "sonar-project.properties"))
 	default_output_directory = "./sonar-reports"
-	derived_data_path = "./DerivedData"
 
 	sonar_run_tests(properties: properties, output_directory: default_output_directory)
 	sonar_run_slather(properties: properties, output_directory: default_output_directory)
@@ -41,7 +40,6 @@ private_lane :sonar_run_tests do |options|
 	destination = options[:properties][:"sonar.swift.simulator"]
 	app_configuration = options[:properties][:"sonar.swift.appConfiguration"]
 	configuration = "Debug" if app_configuration.to_s.empty?
-	derived_data_path = options[:derived_data_path]
 
 	run_tests(
     	workspace: workspace,

--- a/sonar-swift-plugin/src/main/fastlane/sonar.rb
+++ b/sonar-swift-plugin/src/main/fastlane/sonar.rb
@@ -35,18 +35,18 @@ end
 desc "Build and run project to gather compile commands database and test report"
 private_lane :sonar_run_tests do |options|
 	# Extract sonar property values
-	workspace	= options[:properties][:"sonar.swift.workspace"]
+	workspace = options[:properties][:"sonar.swift.workspace"]
 	app_scheme = options[:properties][:"sonar.swift.appScheme"]
 	destination = options[:properties][:"sonar.swift.simulator"]
 	app_configuration = options[:properties][:"sonar.swift.appConfiguration"]
 	configuration = "Debug" if app_configuration.to_s.empty?
 
 	run_tests(
-    	workspace: workspace,
-    	scheme: app_scheme,
+			workspace: workspace,
+			scheme: app_scheme,
 			destination: destination,
 			configuration: configuration,
-    	clean: true,
+			clean: true,
 			code_coverage: true,
 			output_types: "json-compilation-database,junit",
     	output_directory: options[:output_directory],

--- a/sonar-swift-plugin/src/main/shell/run-sonar-swift.sh
+++ b/sonar-swift-plugin/src/main/shell/run-sonar-swift.sh
@@ -525,7 +525,14 @@ fi
 if [ "$lizard" = "on" ]; then
 	if hash $LIZARD_CMD 2>/dev/null; then
 		echo -n 'Running Lizard...'
-  		$LIZARD_CMD --xml "$srcDirs" > sonar-reports/lizard-report.xml
+        IFS=',' read -ra dirs <<< "$srcDirs"
+        srcParams=""
+        for srcParam in "${dirs[@]}"
+        do
+            srcParams="$srcParams\"$srcParam\" "X
+        done
+        runCommand sonar-reports/lizard-report.xml $LIZARD_CMD --xml "${dirs[@]}"
+  		#$LIZARD_CMD --xml $srcParams > sonar-reports/lizard-report.xml
   	else
   		echo 'Skipping Lizard (not installed!)'
   	fi

--- a/sonar-swift-plugin/src/main/shell/run-sonar-swift.sh
+++ b/sonar-swift-plugin/src/main/shell/run-sonar-swift.sh
@@ -312,7 +312,7 @@ if [[ "$workspaceFile" != "" ]] ; then
 else
     buildCmd+=(-project "$projectFile")
 fi
-buildCmd+=(-scheme $appScheme)
+buildCmd+=(-scheme "$appScheme")
 if [[ ! -z "$destinationSimulator" ]]; then
     buildCmd+=(-destination "$destinationSimulator" -destination-timeout 360 COMPILER_INDEX_STORE_ENABLE=NO)
 fi


### PR DESCRIPTION
- Full `:metrics` lane for SonarQube analysis, replicating the behavior of `run-sonar-swift.sh` (Tailor not handled, Lizard disabled, awaiting Lizard Parser fix)
- The lane uses the sonar-project.properties values, so the lane should be generic to all projects.
- Update the SonarQube Fastlane documentation.