### PR TITLE
Fix "The domain/default pair of (xxx, yyy) does not exist"

### DIFF
--- a/sonar-swift-plugin/src/main/shell/run-sonar-swift.sh
+++ b/sonar-swift-plugin/src/main/shell/run-sonar-swift.sh
@@ -206,7 +206,7 @@ binaryNames=''; readParameter binaryNames 'sonar.coverage.binaryNames'
 # Get the path of plist file
 plistFile=`xcodebuild -showBuildSettings -project "${projectFile}" | grep -i 'PRODUCT_SETTINGS_PATH' -m 1 | sed 's/[ ]*PRODUCT_SETTINGS_PATH = //'`
 # Number version from plist if no sonar.projectVersion
-numVerionFromPlist=`defaults read ${plistFile} CFBundleShortVersionString`
+numVersionFromPlist=`defaults read "${plistFile}" CFBundleShortVersionString`
 
 # Read destination simulator
 destinationSimulator=''; readParameter destinationSimulator 'sonar.swift.simulator'
@@ -254,7 +254,7 @@ if [ "$vflag" = "on" ]; then
  	echo "Xcode project file is: $projectFile"
 	echo "Xcode workspace file is: $workspaceFile"
  	echo "Xcode application scheme is: $appScheme"
-    echo "Number version from plist is: $numVerionFromPlist"
+    echo "Number version from plist is: $numVersionFromPlist"
   if [ -n "$unittests" ]; then
  	    echo "Destination simulator is: $destinationSimulator"
  	    echo "Excluded paths from coverage are: $excludedPathsFromCoverage"
@@ -512,7 +512,7 @@ fi
 # The project version from properties file
 numVersionSonarRunner=''; readParameter numVersionSonarRunner 'sonar.projectVersion'
 if [ -z "$numVersionSonarRunner" -o "$numVersionSonarRunner" = " " ]; then
-	numVersionSonarRunner=" --define sonar.projectVersion=$numVerionFromPlist"
+	numVersionSonarRunner=" --define sonar.projectVersion=$numVersionFromPlist"
 else
 	#if we have version number in properties file, we don't overide numVersion for sonar-runner/sonar-scanner command
 	numVersionSonarRunner='';


### PR DESCRIPTION
This issue arises when spaces are present in the path of `PRODUCT_SETTINGS_PATH` and the script `run-sonar-swift.sh` try to retrieve it.
The spaces are not being escaped, showing the following error `"The domain/default pair of (xxx, yyy) does not exist`.

`/Users/JohnAppleseed/Developer/My Project/Supporting Files/Info.plist` is wrongly parsed ❌
`/Users/JohnAppleseed/Developer/MyProject/SupportingFiles/Info.plist` is correctly parsed ✅

This PR aims to fix the first scenario (#152).