### PR TITLE
Support for SwiftLint 0.35.0

### DIFF
--- a/swiftlang/src/main/resources/com/sonar/sqale/swiftlint-model.xml
+++ b/swiftlang/src/main/resources/com/sonar/sqale/swiftlint-model.xml
@@ -1583,6 +1583,32 @@
                     <txt>min</txt>
                 </prop>
             </chc>
+			<chc>
+				<rule-repo>SwiftLint</rule-repo>
+				<rule-key>empty_collection_literal</rule-key>
+				<prop>
+					<key>remediationFunction</key>
+					<txt>CONSTANT_ISSUE</txt>
+				</prop>
+				<prop>
+					<key>offset</key>
+					<val>5</val>
+					<txt>min</txt>
+				</prop>
+			</chc>
+			<chc>
+				<rule-repo>SwiftLint</rule-repo>
+				<rule-key>no_space_in_method_call</rule-key>
+				<prop>
+					<key>remediationFunction</key>
+					<txt>CONSTANT_ISSUE</txt>
+				</prop>
+				<prop>
+					<key>offset</key>
+					<val>10</val>
+					<txt>min</txt>
+				</prop>
+			</chc>
         </chc>
     </chc>
     <chc>
@@ -1771,6 +1797,32 @@
                     <txt>min</txt>
                 </prop>
             </chc>
+			<chc>
+				<rule-repo>SwiftLint</rule-repo>
+				<rule-key>contains_over_filter_count</rule-key>
+				<prop>
+					<key>remediationFunction</key>
+					<txt>CONSTANT_ISSUE</txt>
+				</prop>
+				<prop>
+					<key>offset</key>
+					<val>5</val>
+					<txt>min</txt>
+				</prop>
+			</chc>
+			<chc>
+				<rule-repo>SwiftLint</rule-repo>
+				<rule-key>contains_over_filter_is_empty</rule-key>
+				<prop>
+					<key>remediationFunction</key>
+					<txt>CONSTANT_ISSUE</txt>
+				</prop>
+				<prop>
+					<key>offset</key>
+					<val>5</val>
+					<txt>min</txt>
+				</prop>
+			</chc>
         </chc>
     </chc>
     <chc>

--- a/swiftlang/src/main/resources/com/sonar/sqale/swiftlint-model.xml
+++ b/swiftlang/src/main/resources/com/sonar/sqale/swiftlint-model.xml
@@ -890,6 +890,71 @@
                     <txt>min</txt>
                 </prop>
             </chc>
+			<chc>
+                <rule-repo>SwiftLint</rule-repo>
+                <rule-key>file_types_order</rule-key>
+                <prop>
+                    <key>remediationFunction</key>
+                    <txt>CONSTANT_ISSUE</txt>
+                </prop>
+                <prop>
+                    <key>offset</key>
+                    <val>5</val>
+                    <txt>min</txt>
+                </prop>
+            </chc>
+			<chc>
+                <rule-repo>SwiftLint</rule-repo>
+                <rule-key>legacy_multiple</rule-key>
+                <prop>
+                    <key>remediationFunction</key>
+                    <txt>CONSTANT_ISSUE</txt>
+                </prop>
+                <prop>
+                    <key>offset</key>
+                    <val>5</val>
+                    <txt>min</txt>
+                </prop>
+            </chc>
+			<chc>
+                <rule-repo>SwiftLint</rule-repo>
+                <rule-key>type_contents_order</rule-key>
+                <prop>
+                    <key>remediationFunction</key>
+                    <txt>CONSTANT_ISSUE</txt>
+                </prop>
+                <prop>
+                    <key>offset</key>
+                    <val>5</val>
+                    <txt>min</txt>
+                </prop>
+            </chc>
+			<chc>
+                <rule-repo>SwiftLint</rule-repo>
+                <rule-key>unused_capture_list</rule-key>
+                <prop>
+                    <key>remediationFunction</key>
+                    <txt>CONSTANT_ISSUE</txt>
+                </prop>
+                <prop>
+                    <key>offset</key>
+                    <val>5</val>
+                    <txt>min</txt>
+                </prop>
+            </chc>
+			<chc>
+                <rule-repo>SwiftLint</rule-repo>
+                <rule-key>unused_declaration</rule-key>
+                <prop>
+                    <key>remediationFunction</key>
+                    <txt>CONSTANT_ISSUE</txt>
+                </prop>
+                <prop>
+                    <key>offset</key>
+                    <val>5</val>
+                    <txt>min</txt>
+                </prop>
+            </chc>
         </chc>
         <chc>
             <key>UNDERSTANDABILITY</key>
@@ -1505,6 +1570,19 @@
                     <txt>min</txt>
                 </prop>
             </chc>
+			<chc>
+                <rule-repo>SwiftLint</rule-repo>
+                <rule-key>duplicate_enum_cases</rule-key>
+                <prop>
+                    <key>remediationFunction</key>
+                    <txt>CONSTANT_ISSUE</txt>
+                </prop>
+                <prop>
+                    <key>offset</key>
+                    <val>5</val>
+                    <txt>min</txt>
+                </prop>
+            </chc>
         </chc>
     </chc>
     <chc>
@@ -1624,6 +1702,32 @@
         <chc>
             <key>MEMORY_EFFICIENCY</key>
             <name>Memory use</name>
+			<chc>
+                <rule-repo>SwiftLint</rule-repo>
+                <rule-key>reduce_into</rule-key>
+                <prop>
+                    <key>remediationFunction</key>
+                    <txt>CONSTANT_ISSUE</txt>
+                </prop>
+                <prop>
+                    <key>offset</key>
+                    <val>5</val>
+                    <txt>min</txt>
+                </prop>
+            </chc>
+			<chc>
+                <rule-repo>SwiftLint</rule-repo>
+                <rule-key>unowned_variable_capture</rule-key>
+                <prop>
+                    <key>remediationFunction</key>
+                    <txt>CONSTANT_ISSUE</txt>
+                </prop>
+                <prop>
+                    <key>offset</key>
+                    <val>5</val>
+                    <txt>min</txt>
+                </prop>
+            </chc>
         </chc>
         <chc>
             <key>CPU_EFFICIENCY</key>
@@ -1644,6 +1748,19 @@
             <chc>
                 <rule-repo>SwiftLint</rule-repo>
                 <rule-key>sorted_first_last</rule-key>
+                <prop>
+                    <key>remediationFunction</key>
+                    <txt>CONSTANT_ISSUE</txt>
+                </prop>
+                <prop>
+                    <key>offset</key>
+                    <val>5</val>
+                    <txt>min</txt>
+                </prop>
+            </chc>
+			<chc>
+                <rule-repo>SwiftLint</rule-repo>
+                <rule-key>reduce_boolean</rule-key>
                 <prop>
                     <key>remediationFunction</key>
                     <txt>CONSTANT_ISSUE</txt>
@@ -1886,6 +2003,32 @@
                 <prop>
                     <key>offset</key>
                     <val>10</val>
+                    <txt>min</txt>
+                </prop>
+            </chc>
+			<chc>
+                <rule-repo>SwiftLint</rule-repo>
+                <rule-key>nslocalizedstring_require_bundle</rule-key>
+                <prop>
+                    <key>remediationFunction</key>
+                    <txt>CONSTANT_ISSUE</txt>
+                </prop>
+                <prop>
+                    <key>offset</key>
+                    <val>5</val>
+                    <txt>min</txt>
+                </prop>
+            </chc>
+			<chc>
+                <rule-repo>SwiftLint</rule-repo>
+                <rule-key>nsobject_prefer_isequal</rule-key>
+                <prop>
+                    <key>remediationFunction</key>
+                    <txt>CONSTANT_ISSUE</txt>
+                </prop>
+                <prop>
+                    <key>offset</key>
+                    <val>5</val>
                     <txt>min</txt>
                 </prop>
             </chc>

--- a/swiftlang/src/main/resources/org/sonar/plugins/swiftlint/profile-swiftlint.xml
+++ b/swiftlang/src/main/resources/org/sonar/plugins/swiftlint/profile-swiftlint.xml
@@ -65,6 +65,14 @@
     </rule>
     <rule>
       <repositoryKey>SwiftLint</repositoryKey>
+      <key>contains_over_filter_count</key>
+    </rule>
+    <rule>
+      <repositoryKey>SwiftLint</repositoryKey>
+      <key>contains_over_filter_is_empty</key>
+    </rule>
+    <rule>
+      <repositoryKey>SwiftLint</repositoryKey>
       <key>contains_over_first_not_nil</key>
     </rule>
     <rule>
@@ -118,6 +126,10 @@
     <rule>
       <repositoryKey>SwiftLint</repositoryKey>
       <key>dynamic_inline</key>
+    </rule>
+    <rule>
+      <repositoryKey>SwiftLint</repositoryKey>
+      <key>empty_collection_literal</key>
     </rule>
     <rule>
       <repositoryKey>SwiftLint</repositoryKey>
@@ -378,6 +390,10 @@
     <rule>
       <repositoryKey>SwiftLint</repositoryKey>
       <key>no_grouping_extension</key>
+    </rule>
+    <rule>
+      <repositoryKey>SwiftLint</repositoryKey>
+      <key>no_space_in_method_call</key>
     </rule>
     <rule>
       <repositoryKey>SwiftLint</repositoryKey>

--- a/swiftlang/src/main/resources/org/sonar/plugins/swiftlint/profile-swiftlint.xml
+++ b/swiftlang/src/main/resources/org/sonar/plugins/swiftlint/profile-swiftlint.xml
@@ -109,6 +109,10 @@
     </rule>
     <rule>
       <repositoryKey>SwiftLint</repositoryKey>
+      <key>duplicate_enum_cases</key>
+    </rule>
+    <rule>
+      <repositoryKey>SwiftLint</repositoryKey>
       <key>duplicate_imports</key>
     </rule>
     <rule>
@@ -186,6 +190,10 @@
     <rule>
       <repositoryKey>SwiftLint</repositoryKey>
       <key>file_name</key>
+    </rule>
+    <rule>
+      <repositoryKey>SwiftLint</repositoryKey>
+      <key>file_types_order</key>
     </rule>
     <rule>
       <repositoryKey>SwiftLint</repositoryKey>
@@ -285,6 +293,10 @@
     </rule>
     <rule>
       <repositoryKey>SwiftLint</repositoryKey>
+      <key>legacy_multiple</key>
+    </rule>
+    <rule>
+      <repositoryKey>SwiftLint</repositoryKey>
       <key>legacy_nsgeometry_functions</key>
     </rule>
     <rule>
@@ -377,6 +389,14 @@
     </rule>
     <rule>
       <repositoryKey>SwiftLint</repositoryKey>
+      <key>nslocalizedstring_require_bundle</key>
+    </rule>
+    <rule>
+      <repositoryKey>SwiftLint</repositoryKey>
+      <key>nsobject_prefer_isequal</key>
+    </rule>
+    <rule>
+      <repositoryKey>SwiftLint</repositoryKey>
       <key>number_separator</key>
     </rule>
     <rule>
@@ -450,6 +470,14 @@
     <rule>
       <repositoryKey>SwiftLint</repositoryKey>
       <key>quick_discouraged_pending_test</key>
+    </rule>
+    <rule>
+      <repositoryKey>SwiftLint</repositoryKey>
+      <key>reduce_boolean</key>
+    </rule>
+    <rule>
+      <repositoryKey>SwiftLint</repositoryKey>
+      <key>reduce_into</key>
     </rule>
     <rule>
       <repositoryKey>SwiftLint</repositoryKey>
@@ -577,6 +605,10 @@
     </rule>
     <rule>
       <repositoryKey>SwiftLint</repositoryKey>
+      <key>type_contents_order</key>
+    </rule>
+    <rule>
+      <repositoryKey>SwiftLint</repositoryKey>
       <key>type_name</key>
     </rule>
     <rule>
@@ -593,7 +625,15 @@
     </rule>
     <rule>
       <repositoryKey>SwiftLint</repositoryKey>
+      <key>unowned_variable_capture</key>
+    </rule>
+    <rule>
+      <repositoryKey>SwiftLint</repositoryKey>
       <key>untyped_error_in_catch</key>
+    </rule>
+    <rule>
+      <repositoryKey>SwiftLint</repositoryKey>
+      <key>unused_capture_list</key>
     </rule>
     <rule>
       <repositoryKey>SwiftLint</repositoryKey>
@@ -602,6 +642,10 @@
     <rule>
       <repositoryKey>SwiftLint</repositoryKey>
       <key>unused_control_flow_label</key>
+    </rule>
+    <rule>
+      <repositoryKey>SwiftLint</repositoryKey>
+      <key>unused_declaration</key>
     </rule>
     <rule>
       <repositoryKey>SwiftLint</repositoryKey>
@@ -614,10 +658,6 @@
     <rule>
       <repositoryKey>SwiftLint</repositoryKey>
       <key>unused_optional_binding</key>
-    </rule>
-    <rule>
-      <repositoryKey>SwiftLint</repositoryKey>
-      <key>unused_private_declaration</key>
     </rule>
     <rule>
       <repositoryKey>SwiftLint</repositoryKey>
@@ -654,10 +694,6 @@
     <rule>
       <repositoryKey>SwiftLint</repositoryKey>
       <key>void_return</key>
-    </rule>
-    <rule>
-      <repositoryKey>SwiftLint</repositoryKey>
-      <key>weak_computed_property</key>
     </rule>
     <rule>
       <repositoryKey>SwiftLint</repositoryKey>

--- a/swiftlang/src/main/resources/org/sonar/plugins/swiftlint/rules.json
+++ b/swiftlang/src/main/resources/org/sonar/plugins/swiftlint/rules.json
@@ -108,7 +108,7 @@
         "key": "contains_over_first_not_nil",
         "category": "SwiftLint",
         "name": "Contains over first not nil",
-        "description": "Prefer `contains` over `first(where:) != nil`",
+        "description": "Prefer `contains` over `first(where:) != nil` and `firstIndex(where:) != nil`.",
         "severity": "MINOR"
     },
     {
@@ -179,6 +179,13 @@
         "category": "SwiftLint",
         "name": "Discouraged Optional Collection",
         "description": "Prefer empty collection over optional collection.",
+        "severity": "MINOR"
+    },
+    {
+        "key": "duplicate_enum_cases",
+        "category": "SwiftLint",
+        "name": "Duplicate Enum Cases",
+        "description": "Enum can't contain multiple cases with the same name.",
         "severity": "MINOR"
     },
     {
@@ -319,6 +326,13 @@
         "category": "SwiftLint",
         "name": "File Name",
         "description": "File name should match a type or extension declared in the file (if any).",
+        "severity": "MINOR"
+    },
+    {
+        "key": "file_types_order",
+        "category": "SwiftLint",
+        "name": "File Types Order",
+        "description": "Specifies how the types within a file should be ordered.",
         "severity": "MINOR"
     },
     {
@@ -490,6 +504,13 @@
         "severity": "MINOR"
     },
     {
+        "key": "legacy_multiple",
+        "category": "SwiftLint",
+        "name": "Legacy Multiple",
+        "description": "Prefer using the `isMultiple(of:)` function instead of using the remainder operator (`%`).",
+        "severity": "MINOR"
+    },
+    {
         "key": "legacy_nsgeometry_functions",
         "category": "SwiftLint",
         "name": "Legacy NSGeometry Functions",
@@ -651,6 +672,20 @@
         "severity": "MINOR"
     },
     {
+        "key": "nslocalizedstring_require_bundle",
+        "category": "SwiftLint",
+        "name": "NSLocalizedString Require Bundle",
+        "description": "Calls to NSLocalizedString should specify the bundle which contains the strings file.",
+        "severity": "MINOR"
+    },
+    {
+        "key": "nsobject_prefer_isequal",
+        "category": "SwiftLint",
+        "name": "NSObject Prefer isEqual",
+        "description": "NSObject subclasses should implement isEqual instead of ==.",
+        "severity": "MINOR"
+    },
+    {
         "key": "number_separator",
         "category": "SwiftLint",
         "name": "Number Separator",
@@ -781,6 +816,20 @@
         "category": "SwiftLint",
         "name": "Quick Discouraged Pending Test",
         "description": "Discouraged pending test. This test won't run while it's marked as pending.",
+        "severity": "MINOR"
+    },
+    {
+        "key": "reduce_boolean",
+        "category": "SwiftLint",
+        "name": "Reduce Boolean",
+        "description": "Prefer using `.allSatisfy()` or `.contains()` over `reduce(true)` or `reduce(false)`",
+        "severity": "MINOR"
+    },
+    {
+        "key": "reduce_into",
+        "category": "SwiftLint",
+        "name": "Reduce Into",
+        "description": "Prefer `reduce(into:_:)` over `reduce(_:_:)` for copy-on-write types",
         "severity": "MINOR"
     },
     {
@@ -920,7 +969,7 @@
         "key": "superfluous_disable_command",
         "category": "SwiftLint",
         "name": "Superfluous Disable Command",
-        "description": "SwiftLint 'disable' commands are superfluous when the disabled rule would not have triggered a violation in the disabled region.",
+        "description": "SwiftLint 'disable' commands are superfluous when the disabled rule would not have triggered a violation in the disabled region. Use \" - \" if you wish to document a command.",
         "severity": "MINOR"
     },
     {
@@ -1001,6 +1050,13 @@
         "severity": "MAJOR"
     },
     {
+        "key": "type_contents_order",
+        "category": "SwiftLint",
+        "name": "Type Contents Order",
+        "description": "Specifies the order of subtypes, properties, methods & more within a type.",
+        "severity": "MINOR"
+    },
+    {
         "key": "type_name",
         "category": "SwiftLint",
         "name": "Type Name",
@@ -1029,10 +1085,24 @@
         "severity": "MINOR"
     },
     {
+        "key": "unowned_variable_capture",
+        "category": "SwiftLint",
+        "name": "Unowned Variable Capture",
+        "description": "Prefer capturing references as weak to avoid potential crashes.",
+        "severity": "MINOR"
+    },
+    {
         "key": "untyped_error_in_catch",
         "category": "SwiftLint",
         "name": "Untyped Error in Catch",
         "description": "Catch statements should not declare error variables without type casting.",
+        "severity": "MINOR"
+    },
+    {
+        "key": "unused_capture_list",
+        "category": "SwiftLint",
+        "name": "Unused Capture List",
+        "description": "Unused reference in a capture list should be removed.",
         "severity": "MINOR"
     },
     {
@@ -1047,6 +1117,13 @@
         "category": "SwiftLint",
         "name": "Unused Control Flow Label",
         "description": "Unused control flow label should be removed.",
+        "severity": "MINOR"
+    },
+    {
+        "key": "unused_declaration",
+        "category": "SwiftLint",
+        "name": "Unused Declaration",
+        "description": "Declarations should be referenced at least once within all files linted.",
         "severity": "MINOR"
     },
     {
@@ -1068,13 +1145,6 @@
         "category": "SwiftLint",
         "name": "Unused Optional Binding",
         "description": "Prefer `!= nil` over `let _ =`",
-        "severity": "MINOR"
-    },
-    {
-        "key": "unused_private_declaration",
-        "category": "SwiftLint",
-        "name": "Unused Private Declaration",
-        "description": "Private declarations should be referenced in that file.",
         "severity": "MINOR"
     },
     {
@@ -1138,13 +1208,6 @@
         "category": "SwiftLint",
         "name": "Void Return",
         "description": "Prefer `-> Void` over `-> ()`.",
-        "severity": "MINOR"
-    },
-    {
-        "key": "weak_computed_property",
-        "category": "SwiftLint",
-        "name": "Weak Computed Property",
-        "description": "Adding weak to a computed property has no effect.",
         "severity": "MINOR"
     },
     {

--- a/swiftlang/src/main/resources/org/sonar/plugins/swiftlint/rules.json
+++ b/swiftlang/src/main/resources/org/sonar/plugins/swiftlint/rules.json
@@ -105,6 +105,20 @@
         "severity": "MINOR"
     },
     {
+        "key": "contains_over_filter_count",
+        "category": "SwiftLint",
+        "name": "Contains Over Filter Count",
+        "description": "Prefer `contains` over comparing `filter(where:).count` to 0.",
+        "severity": "MINOR"
+    },
+    {
+        "key": "contains_over_filter_is_empty",
+        "category": "SwiftLint",
+        "name": "Contains Over Filter Is Empty",
+        "description": "Prefer `contains` over using `filter(where:).isEmpty`",
+        "severity": "MINOR"
+    },
+    {
         "key": "contains_over_first_not_nil",
         "category": "SwiftLint",
         "name": "Contains over first not nil",
@@ -200,6 +214,13 @@
         "category": "SwiftLint",
         "name": "Dynamic Inline",
         "description": "Avoid using 'dynamic' and '@inline(__always)' together.",
+        "severity": "MINOR"
+    },
+    {
+        "key": "empty_collection_literal",
+        "category": "SwiftLint",
+        "name": "Empty Collection Literal",
+        "description": "Prefer checking `isEmpty` over comparing collection to an empty array or dictionary literal.",
         "severity": "MINOR"
     },
     {
@@ -655,6 +676,13 @@
         "category": "SwiftLint",
         "name": "No Grouping Extension",
         "description": "Extensions shouldn't be used to group code within the same source file.",
+        "severity": "MINOR"
+    },
+    {
+        "key": "no_space_in_method_call",
+        "category": "SwiftLint",
+        "name": "No Space in Method Call",
+        "description": "Don't add a space between the method name and the parentheses.",
         "severity": "MINOR"
     },
     {


### PR DESCRIPTION
Add `duplicate_enum_cases`, `file_types_order`, `legacy_multiple`, `nslocalizedstring_require_bundle`, `nsobject_prefer_isequal`, `reduce_boolean`, `reduce_into`, `type_contents_order`, `unowned_variable_capture`, `unused_capture_list`, `unused_declaration`, `no_space_in_method_call`, `contains_over_filter_count`, `contains_over_filter_is_empty`, `empty_collection_literal`.

Remove `unused_private_declaration`, `weak_computed_property`.