### PR TITLE
Fix Lizard command & NPE

### DIFF
--- a/sonar-swift-plugin/src/main/java/com/backelite/sonarqube/swift/complexity/LizardReportParser.java
+++ b/sonar-swift-plugin/src/main/java/com/backelite/sonarqube/swift/complexity/LizardReportParser.java
@@ -113,10 +113,13 @@ public class LizardReportParser {
             if (item.getNodeType() == Node.ELEMENT_NODE) {
                 Element itemElement = (Element) item;
                 String name = itemElement.getAttribute(NAME);
-
                 NodeList values = itemElement.getElementsByTagName(VALUE);
+                
                 if (FILE_MEASURE.equalsIgnoreCase(type)) {
                     InputFile inputFile = getFile(name);
+                    // the file could be excluded from Sonar analysis
+                    // hence not found in the filesystem
+                    if (inputFile == null) { continue; }
                     addComplexityFileMeasures(inputFile, values);
                 } else if (FUNCTION_MEASURE.equalsIgnoreCase(type)) {
                     addComplexityFunctionMeasures(new SwiftFunction(0,name), values);

--- a/sonar-swift-plugin/src/main/shell/run-sonar-swift.sh
+++ b/sonar-swift-plugin/src/main/shell/run-sonar-swift.sh
@@ -501,7 +501,15 @@ fi
 if [ "$lizard" = "on" ]; then
 	if hash $LIZARD_CMD 2>/dev/null; then
 		echo -n 'Running Lizard...'
-  		$LIZARD_CMD --xml "$srcDirs" > sonar-reports/lizard-report.xml
+		lizardCmd=($LIZARD_CMD --xml)
+
+		echo "$srcDirs" | sed -n 1'p' | tr ',' '\n' > tmpFileRunSonarSh
+		while read word; do
+			lizardCmd+=( "$word")
+		done < tmpFileRunSonarSh
+		rm -rf tmpFileRunSonarSh
+
+		runCommand  sonar-reports/lizard-report.xml "${lizardCmd[@]}"
   	else
   		echo 'Skipping Lizard (not installed!)'
   	fi


### PR DESCRIPTION
Current Lizard command do not produce any report because it contains quote.
`lizard --xml "MyFolder MyOther Folder" > sonar-reports/lizard-report.xml` ❌
Now the command look like this:
`lizard --xml "MyFolder" "MyOther Folder" > sonar-reports/lizard-report.xml` ✅
Bonus spaces in name are supported 🎉

Other issue arises when a file is excluded from analysis, producing a NPE.